### PR TITLE
Allow sending base64 content to the endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,19 @@ The default format is "Letter" (US) but it can be set to other paper formats lik
 curl \
 -d '{"html": "<h1>Hello World</h1>", "export": {"format": "A4"}}' \
 -H "Content-Type: application/json" \
+--output hello-base64.pdf \
+-XPOST "http://localhost:2305/1/pdf"
+```
+
+For larger and more a more complex payload it might be easier to send the data as base64 string:
+```bash
+curl \
+-d '{"html": "PGI+aGVsbG8gd29ybGQgPGltZyBzcmM9Imh0dHBzOi8vd3d3LnBsYWNlYmVhci5jb20vNDAwLzMwMCIgLz48L2I+", "base64": true, "export": {"format": "A4"}}' \
+-H "Content-Type: application/json" \
 --output hello-a4.pdf \
 -XPOST "http://localhost:2305/1/pdf"
 ```
+
 
 ## Generating a PNG
 
@@ -52,6 +62,15 @@ curl \
 ```
 
 Now open `hello.png`
+
+The screenshot endpoint also has the option to send data as base64:
+```bash
+curl \
+-d '{"html": "PGI+aGVsbG8gd29ybGQgPGltZyBzcmM9Imh0dHBzOi8vd3d3LnBsYWNlYmVhci5jb20vNDAwLzMwMCIgLz48L2I+", "base64": true, "export": {"type": "png"}}' \
+-H "Content-Type: application/json" \
+--output hello-base64.png \
+-XPOST "http://localhost:2305/1/screenshot"
+```
 
 ## Advanced Options
 

--- a/script/test.sh
+++ b/script/test.sh
@@ -10,5 +10,6 @@ curl -X POST -H "Accept: application/json" -H "Content-type: application/json"  
 }' 'http://localhost:2305/1/pdf' --output test_base64.pdf
 
 curl -X POST -H "Accept: application/json" -H "Content-type: application/json"  -d '{
-    "html": "<b>hello world <img src=\"https://www.placebear.com/400/300\"/></b>"
+    "html": "<b>hello world <img src=\"https://www.placebear.com/400/300\"/></b>",
+    "export": {"type": "png"}
 }' 'http://localhost:2305/1/screenshot' --output test.png

--- a/script/test.sh
+++ b/script/test.sh
@@ -13,3 +13,9 @@ curl -X POST -H "Accept: application/json" -H "Content-type: application/json"  
     "html": "<b>hello world <img src=\"https://www.placebear.com/400/300\"/></b>",
     "export": {"type": "png"}
 }' 'http://localhost:2305/1/screenshot' --output test.png
+
+curl -X POST -H "Accept: application/json" -H "Content-type: application/json"  -d '{
+    "html": "PGI+aGVsbG8gd29ybGQgPGltZyBzcmM9Imh0dHBzOi8vd3d3LnBsYWNlYmVhci5jb20vNDAwLzMwMCIgLz48L2I+",
+    "base64": true,
+    "export": {"type": "png"}
+}' 'http://localhost:2305/1/screenshot' --output test_base64.png

--- a/script/test.sh
+++ b/script/test.sh
@@ -5,5 +5,10 @@ curl -X POST -H "Accept: application/json" -H "Content-type: application/json"  
 }' 'http://localhost:2305/1/pdf' --output test.pdf
 
 curl -X POST -H "Accept: application/json" -H "Content-type: application/json"  -d '{
+    "html": "PGI+aGVsbG8gd29ybGQgPGltZyBzcmM9Imh0dHBzOi8vd3d3LnBsYWNlYmVhci5jb20vNDAwLzMwMCIgLz48L2I+",
+    "base64": true
+}' 'http://localhost:2305/1/pdf' --output test_base64.pdf
+
+curl -X POST -H "Accept: application/json" -H "Content-type: application/json"  -d '{
     "html": "<b>hello world <img src=\"https://www.placebear.com/400/300\"/></b>"
 }' 'http://localhost:2305/1/screenshot' --output test.png

--- a/src/app.js
+++ b/src/app.js
@@ -73,7 +73,14 @@ router.post(
     const body = ctx.request.body;
     const browser = await getBrowser();
     const page = await browser.newPage();
-    await page.setContent(body.html, { waitUntil: "load" });
+
+    let html = body.html;
+    if(body.base64) {
+      let buffer = Buffer.from(html, 'base64');
+      html = buffer.toString('ascii');
+    }
+
+    await page.setContent(html, { waitUntil: "load" });
     const options = body.export;
     if (options.type === "png") {
       delete options.quality;

--- a/src/app.js
+++ b/src/app.js
@@ -52,6 +52,7 @@ router.post(
   validate({
     body: Joi.object({
       html: Joi.string().required(),
+      base64: Joi.boolean().default(false),
       export: Joi.object({
         scale: Joi.number().min(0.1).max(2).default(1),
         type: Joi.string().allow("jpeg", "png").default("png"),
@@ -88,6 +89,7 @@ router.post(
   validate({
     body: Joi.object({
       html: Joi.string().required(),
+      base64: Joi.boolean().default(false),
       export: Joi.object({
         scale: Joi.number().default(1),
         displayHeaderFooter: Joi.boolean().default(true),
@@ -128,7 +130,13 @@ router.post(
     const browser = await getBrowser();
     const page = await browser.newPage();
 
-    await page.setContent(body.html, { waitUntil: "load" });
+    let html = body.html;
+    if(body.base64) {
+      let buffer = Buffer.from(html, 'base64');
+      html = buffer.toString('ascii');
+    }
+
+    await page.setContent(html, { waitUntil: "load" });
     ctx.body = await page.pdf(body.export);
     await page.close();
   }


### PR DESCRIPTION
Hello,

### Why this PR
I plan to use this service to generate documents like pdf invoices, and contracts. When the payload becomes really large and complex, it can be painful to submit as a regular HTML string. In the base, I had good experience sending such a payload as a base64 string.

### What I did
I created a new parameter for both endpoints (screenshot and pdf) to send a parameter called "base64" which is a  boolean. If true, the application will decode the HTML content parameter from base64 to ascii.
To not change the current API, I made this parameter optional and default as false. So there is no new API version needed.

I also implemented new tests for both endpoints and corrected the screenshot endpoint test. There was an issue with the payload.

The documentation was also updated.

### What tests I did

- docker-compose build and run
- Run the test script against the new container and validate all 4 responses
- Run all curl statements from README against the new container and test the response

### Some more notes
I am not a javascript/node developer so please have mercy. Maybe there are better ways to do my change? I am open to any review and recommendation.

Thanks,
Jonah