### PR TITLE
Fixed load web font in screenshot endpoint

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -83,6 +83,10 @@ router.post(
     } else {
       await page.setContent(body.html, { waitUntil: "load" });
     }
+    // Wait for all fonts to be loaded
+    await page.evaluate(async () => {
+      await document.fonts.ready;
+    });
     const options = body.export;
     if (options.type === "png") {
       delete options.quality;


### PR DESCRIPTION
Hi, I've created a PR to fix the loading of web fonts in the screenshot endpoint. The web fonts work well with PDFs, but they don't work for images.
```
// Wait for all fonts to be loaded
await page.evaluate(async () => {
      await document.fonts.ready;
});
```